### PR TITLE
fix ImageScannerModule responses

### DIFF
--- a/ios/ImageScannerModule.swift
+++ b/ios/ImageScannerModule.swift
@@ -7,39 +7,36 @@ import MLKitImageLabeling
 @objc(ImageScannerModule)
 class ImageScannerModule: NSObject {
 
-    private var data: [Any] = []
-
     @objc(process:orientation:minConfidence:withResolver:withRejecter:)
-    private func process(uri: String,orientation:String,minConfidence:Double, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    private func process(uri: String, orientation: String, minConfidence: Double, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        var data: [Any] = []
+        let image = UIImage(contentsOfFile: uri)
+        let options = ImageLabelerOptions()
+        options.confidenceThreshold = NSNumber(value: minConfidence)
+        let labeler = ImageLabeler.imageLabeler(options: options)
 
-            let image =  UIImage(contentsOfFile: uri)
-            let options = ImageLabelerOptions()
-            options.confidenceThreshold = (minConfidence) as NSNumber
-            let labeler = ImageLabeler.imageLabeler(options: options)
-            if image != nil {
-                do {
-                    let visionImage = VisionImage(image: image!)
-                    visionImage.orientation = getOrientation(orientation: orientation)
-                    let labels = try labeler.results(in: visionImage)
+        if let image = image {
+            do {
+                let visionImage = VisionImage(image: image)
+                visionImage.orientation = getOrientation(orientation: orientation)
+                let labels = try labeler.results(in: visionImage)
 
-                    for label in labels {
-                        var obj : [String:Any] = [:]
-                        obj["labelText"] = label.text
-                        obj["confidence"] = label.confidence
-                        data.append(obj)
-                        if label.text.isEmpty {
-                            resolve([])
-                        }else{
-                            resolve(data)
-                        }
-                    }
-                }catch{
-                    reject("Error","Processing Image",nil)
+                for label in labels {
+                    var obj: [String: Any] = [:]
+                    obj["labelText"] = label.text
+                    obj["confidence"] = label.confidence
+                    data.append(obj)
                 }
-            }else{
-                reject("Error","Can't Find Photo",nil)
+
+                resolve(data)
+            } catch {
+                reject("Error", "Processing Image", nil)
             }
+        } else {
+            reject("Error", "Can't Find Photo", nil)
+        }
     }
+
         private func getOrientation(
           orientation: String
         ) -> UIImage.Orientation {


### PR DESCRIPTION
Hi,

When using the iOS `ImageScanner` module in React Native, I noticed that each time the function is called, it keeps appending to the data variable without clearing it. Additionally, the `resolve` function is being triggered multiple times because it's inside a for loop, which causes multiple resolves in an exception being thrown in the app. This pull request addresses that issue.